### PR TITLE
Use joblib to parallelize downloads

### DIFF
--- a/download_images.sh
+++ b/download_images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-pip3 install -U pandas tqdm
+pip3 install -U pandas tqdm joblib
 
 OUTPUT_DIRPATH="images"
 CSV_FILEPATH="Task2/book32-listing.csv"


### PR DESCRIPTION
Download files in parallel with joblib. Prevent overwrites and attempts to download already downloaded files, making resumes easier.

![screenshot from 2018-04-29 02-30-16](https://user-images.githubusercontent.com/5781617/39401740-53df19c4-4b55-11e8-86dd-f1628c908b12.png)
